### PR TITLE
Add Japanese translation

### DIFF
--- a/Volna42/src/LocaleDe.h
+++ b/Volna42/src/LocaleDe.h
@@ -1,0 +1,33 @@
+#define LOCALE_CONFIGURED
+
+const char defaultLocale[] PROGMEM = "de";
+
+const char noWiFi[] PROGMEM = "WLAN-Verbindung verloren";
+
+const char locIndoor[] PROGMEM = "innen";
+const char locOutdoor[] PROGMEM = "außen";
+const char locHumidity[] PROGMEM = "Luftfeuchte";
+const char locTemp[] PROGMEM = "Temperatur";
+const char locUnavailable[] PROGMEM = "Sensor nicht verfügbar";
+const char locLowBat[] PROGMEM = "Niedriger Batteriestand";
+
+const char locShortMonday[] PROGMEM = "Mo";
+const char locShortTuesday[] PROGMEM = "Di";
+const char locShortWednesday[] PROGMEM = "Mi";
+const char locShortThursday[] PROGMEM = "Do";
+const char locShortFriday[] PROGMEM = "Fr";
+const char locShortSaturday[] PROGMEM = "Sa";
+const char locShortSunday[] PROGMEM = "So";
+
+const char locMonth1January[] PROGMEM = "Januar";
+const char locMonth2February[] PROGMEM = "Februar";
+const char locMonth3March[] PROGMEM = "März";
+const char locMonth4April[] PROGMEM = "April";
+const char locMonth5May[] PROGMEM = "May";
+const char locMonth6June[] PROGMEM = "Juni";
+const char locMonth7July[] PROGMEM = "Juli";
+const char locMonth8August[] PROGMEM = "August";
+const char locMonth9September[] PROGMEM = "September";
+const char locMonth10October[] PROGMEM = "Oktober";
+const char locMonth11November[] PROGMEM = "November";
+const char locMonth12December[] PROGMEM = "Dezember";

--- a/Volna42/src/LocaleJa.h
+++ b/Volna42/src/LocaleJa.h
@@ -1,0 +1,33 @@
+#define LOCALE_CONFIGURED
+
+const char defaultLocale[] PROGMEM = "ja";
+
+const char noWiFi[] PROGMEM = "WiFi接続が失われました";
+
+const char locIndoor[] PROGMEM = "屋内";
+const char locOutdoor[] PROGMEM = "屋外";
+const char locHumidity[] PROGMEM = "湿度";
+const char locTemp[] PROGMEM = "温度";
+const char locUnavailable[] PROGMEM = "センサーが利用できません";
+const char locLowBat[] PROGMEM = "バッテリー残量が少ない";
+
+const char locShortMonday[] PROGMEM = "月曜日";
+const char locShortTuesday[] PROGMEM = "、火曜日";
+const char locShortWednesday[] PROGMEM = "水曜日";
+const char locShortThursday[] PROGMEM = "木曜日";
+const char locShortFriday[] PROGMEM = "金曜日";
+const char locShortSaturday[] PROGMEM = "土曜日";
+const char locShortSunday[] PROGMEM = "日曜日";
+
+const char locMonth1January[] PROGMEM = "1月";
+const char locMonth2February[] PROGMEM = "2月";
+const char locMonth3March[] PROGMEM = "3月";
+const char locMonth4April[] PROGMEM = "4月";
+const char locMonth5May[] PROGMEM = "5月";
+const char locMonth6June[] PROGMEM = "6月";
+const char locMonth7July[] PROGMEM = "7月";
+const char locMonth8August[] PROGMEM = "8月";
+const char locMonth9September[] PROGMEM = "9月";
+const char locMonth10October[] PROGMEM = "10月";
+const char locMonth11November[] PROGMEM = "11月";
+const char locMonth12December[] PROGMEM = "12月";


### PR DESCRIPTION
Non-native speaker (JLPT roughly N4), and not fully sure with the more complicated translations.

Regarding printing the date: in Japanese you usually write 3月1日 for March 1st, which is not yet covered in the way the translation file works right now.

It's a starting point, but I'd highly recommend having a native speaker check and maybe suggest improvements.